### PR TITLE
fix: reduce playback stutter and handle stream teardown errors gracef…

### DIFF
--- a/src/bot/extractors/play-dl.ts
+++ b/src/bot/extractors/play-dl.ts
@@ -164,6 +164,25 @@ export class PlayDLExtractor extends BaseExtractor {
 	private createYtDlpStream(youtubeUrl: string): Readable {
 		const subprocess = youtubedl.exec(youtubeUrl, getYtDlpStreamFlags());
 		const output = new PassThrough({ highWaterMark: 1024 * 1024 * 4 });
+		let cleaned = false;
+
+		const cleanup = () => {
+			if (cleaned) return;
+			cleaned = true;
+			subprocess.stdout?.unpipe(output);
+			if (!subprocess.killed) subprocess.kill("SIGKILL");
+		};
+
+		const isBenignPipeError = (err: unknown): boolean => {
+			const code = (err as NodeJS.ErrnoException)?.code;
+			const message =
+				err instanceof Error ? err.message.toLowerCase() : String(err);
+			return (
+				code === "EPIPE" ||
+				message.includes("broken pipe") ||
+				message.includes("premature close")
+			);
+		};
 
 		subprocess.stdout?.pipe(output);
 
@@ -174,19 +193,38 @@ export class PlayDLExtractor extends BaseExtractor {
 			}
 		});
 
+		subprocess.on("error", (err) => {
+			if (!isBenignPipeError(err)) {
+				console.warn(`[yt-dlp] subprocess error: ${err.message}`);
+			}
+			cleanup();
+		});
+
+		subprocess.stdout?.on("error", (err) => {
+			if (!isBenignPipeError(err)) {
+				console.warn(`[yt-dlp] stdout error: ${err.message}`);
+			}
+			cleanup();
+		});
+
 		subprocess.on("close", (code) => {
-			if (code !== 0 && code !== null) {
+			if (code !== 0 && code !== null && !cleaned) {
 				console.warn(
 					`[yt-dlp] process exited with code ${code} for ${youtubeUrl}`,
 				);
 			}
-			if (!subprocess.killed) subprocess.kill("SIGKILL");
-			output.end();
+			cleanup();
+			if (!output.destroyed) output.end();
 		});
 
-		output.on("error", () => {
-			if (!subprocess.killed) subprocess.kill("SIGKILL");
+		output.on("error", (err) => {
+			if (!isBenignPipeError(err)) {
+				console.warn(`[yt-dlp] stream error: ${err.message}`);
+			}
+			cleanup();
 		});
+
+		output.on("close", cleanup);
 
 		return output;
 	}

--- a/src/bot/service.ts
+++ b/src/bot/service.ts
@@ -9,7 +9,9 @@ import {
 import { glob } from "glob";
 import type { BotConfig } from "../config";
 import { createLogger } from "../logger";
+import { ffmpegInputArgs } from "../player-config";
 import {
+	isStreamTeardownError,
 	isYoutubeBackedTrack,
 	isYoutubeStreamError,
 	trySoundCloudBridge,
@@ -165,15 +167,6 @@ export class BotService {
 		});
 
 		player.events.on("playerStart", (queue, track) => {
-			queue.filters.ffmpeg.setInputArgs([
-				"-probesize",
-				"32",
-				"-analyzeduration",
-				"0",
-				"-fflags",
-				"+genpts",
-			]);
-
 			this.logger.log(`Now playing: ${track.title}`);
 			queue.metadata.channel?.send(
 				`🎶 | Now playing: **${track.title}** by **${track.author}**\n` +
@@ -212,13 +205,9 @@ export class BotService {
 		});
 
 		player.events.on("error", (queue, error) => {
-			if (
-				error.name === "AbortError" ||
-				error.message.includes("The operation was aborted") ||
-				(error as NodeJS.ErrnoException).code === "ABORT_ERR"
-			) {
+			if (isStreamTeardownError(error)) {
 				this.logger.debug(
-					`[player] stream aborted (expected): ${error.message}`,
+					`[player] stream teardown (expected): ${error.message}`,
 				);
 				return;
 			}
@@ -227,13 +216,9 @@ export class BotService {
 		});
 
 		player.events.on("playerError", async (queue, error, track) => {
-			if (
-				error.name === "AbortError" ||
-				error.message.includes("The operation was aborted") ||
-				(error as NodeJS.ErrnoException).code === "ABORT_ERR"
-			) {
+			if (isStreamTeardownError(error)) {
 				this.logger.debug(
-					`[player] stream aborted (expected): ${error.message}`,
+					`[player] stream teardown (expected): ${error.message}`,
 				);
 				return;
 			}
@@ -283,7 +268,8 @@ export class BotService {
 
 		player.events.on(
 			"willPlayTrack" as any,
-			(_queue: any, track: any, _config: any, done: () => void) => {
+			(queue: any, track: any, _config: any, done: () => void) => {
+				queue.filters.ffmpeg.setInputArgs([...ffmpegInputArgs]);
 				this.logger.debug(
 					`[willPlayTrack] ${track?.title} | extractor: ${track?.extractor?.identifier}`,
 				);

--- a/src/player-config.ts
+++ b/src/player-config.ts
@@ -1,11 +1,23 @@
 import type { GuildNodeCreateOptions } from "discord-player";
 
+/** FFmpeg input tuning for piped yt-dlp streams (smooth playback, not ultra-low probe). */
+export const ffmpegInputArgs = [
+	"-probesize",
+	"32768",
+	"-analyzeduration",
+	"500000",
+	"-fflags",
+	"+genpts",
+	"-thread_queue_size",
+	"512",
+] as const;
+
 export const defaultNodeOptions: GuildNodeCreateOptions = {
 	leaveOnEmpty: true,
 	leaveOnEmptyCooldown: 60_000,
 	leaveOnEnd: true,
 	leaveOnEndCooldown: 60_000,
 	selfDeaf: true,
-	bufferingTimeout: 0,
+	bufferingTimeout: 10_000,
 	connectionTimeout: 30_000,
 };

--- a/src/stream-fallback.test.ts
+++ b/src/stream-fallback.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { isStreamTeardownError, isYoutubeStreamError } from "./stream-fallback";
+
+describe("isStreamTeardownError", () => {
+	it("detects EPIPE and broken pipe", () => {
+		expect(
+			isStreamTeardownError(
+				Object.assign(new Error("write EPIPE"), { code: "EPIPE" }),
+			),
+		).toBe(true);
+		expect(isStreamTeardownError(new Error("Broken pipe"))).toBe(true);
+		expect(isStreamTeardownError(new Error("premature close"))).toBe(true);
+	});
+
+	it("detects abort errors", () => {
+		expect(
+			isStreamTeardownError(
+				Object.assign(new Error("aborted"), { name: "AbortError" }),
+			),
+		).toBe(true);
+	});
+});
+
+describe("isYoutubeStreamError", () => {
+	it("does not treat teardown errors as YouTube failures", () => {
+		expect(
+			isYoutubeStreamError(
+				Object.assign(new Error("write EPIPE"), { code: "EPIPE" }),
+			),
+		).toBe(false);
+	});
+
+	it("detects real YouTube extraction failures", () => {
+		expect(
+			isYoutubeStreamError(new Error("Sign in to confirm you're not a bot")),
+		).toBe(true);
+		expect(
+			isYoutubeStreamError(
+				Object.assign(new Error("failed"), { stderr: "yt-dlp: ERROR" }),
+			),
+		).toBe(true);
+	});
+});

--- a/src/stream-fallback.ts
+++ b/src/stream-fallback.ts
@@ -6,7 +6,25 @@ export const SOUNDCLOUD_EXTRACTOR_ID =
 
 const fallbackUsed = new WeakMap<Track, string[]>();
 
+/** Expected when skip/stop tears down FFmpeg while yt-dlp is still piping. */
+export function isStreamTeardownError(error: Error): boolean {
+	const code = (error as NodeJS.ErrnoException).code;
+	const msg = error.message.toLowerCase();
+
+	return (
+		error.name === "AbortError" ||
+		code === "ABORT_ERR" ||
+		code === "EPIPE" ||
+		msg.includes("the operation was aborted") ||
+		msg.includes("broken pipe") ||
+		msg.includes("write epipe") ||
+		msg.includes("premature close") ||
+		msg.includes("stream destroyed")
+	);
+}
+
 export function isYoutubeStreamError(error: Error): boolean {
+	if (isStreamTeardownError(error)) return false;
 	const stderr = (error as { stderr?: string }).stderr ?? "";
 	const msg = `${error.message}\n${stderr}`.toLowerCase();
 

--- a/src/yt-dlp.ts
+++ b/src/yt-dlp.ts
@@ -5,6 +5,7 @@ import youtubedlDefault, { create as createYoutubeDl } from "youtube-dl-exec";
 type YtDlpFlags = Flags & {
 	extractorArgs?: string;
 	fragmentRetries?: number;
+	httpChunkSize?: string;
 };
 
 const DEFAULT_COOKIE_PATHS = [
@@ -100,8 +101,9 @@ function buildExtractorArgs(): string {
 
 export function getYtDlpStreamFlags(): YtDlpFlags {
 	const flags: YtDlpFlags = {
-		// Prefer progressive HTTPS (format 18). Avoid m3u8/HLS — it stutters when piped.
-		format: "best[format_id=18]/best[ext=mp4][protocol=https]/ba/b",
+		// HTTPS progressive audio only — never fall back to DASH/HLS (stutters when piped).
+		format:
+			"ba[protocol=https]/bestaudio[protocol=https]/best[format_id=18]/best[ext=mp4][protocol=https]",
 		output: "-",
 		noPart: true,
 		quiet: true,
@@ -109,6 +111,7 @@ export function getYtDlpStreamFlags(): YtDlpFlags {
 		retries: 10,
 		fragmentRetries: 10,
 		skipUnavailableFragments: true,
+		httpChunkSize: "10M",
 		extractorArgs: buildExtractorArgs(),
 		remoteComponent: "ejs:github",
 		jsRuntimes: YT_DLP_JS_RUNTIME,


### PR DESCRIPTION
…ully

Tune FFmpeg and yt-dlp for smoother piped audio, and treat EPIPE/broken pipe as expected on skip/stop so the queue no longer hangs or retries SoundCloud incorrectly.